### PR TITLE
Lock omniauth-oauth2 to version 1.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     registrar (1.0.0)
       omniauth
       omniauth-google-oauth2
+      omniauth-oauth2 (~> 1.3.1)
       rails (>= 4.2.0)
 
 GEM
@@ -129,8 +130,8 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    sprockets (3.3.4)
-      rack (~> 1.0)
+    sprockets (3.3.5)
+      rack (> 1, < 3)
     sprockets-rails (2.3.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)

--- a/registrar.gemspec
+++ b/registrar.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 4.2.0"
   s.add_dependency "omniauth"
   s.add_dependency "omniauth-google-oauth2"
+  s.add_dependency "omniauth-oauth2", "~> 1.3.1"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "pg"


### PR DESCRIPTION
omniauth-oauth2 is the oauth library that omniauth plugins use under the
hood. Version 1.4.0 introduced a bug causing most requests to fail,
which can be found here: https://github.com/intridea/omniauth-oauth2/issues/81
It should be fixed in future versions, at which point this change can be
reverted. But for now, this gets registrar working again.

Confirmed to fix the problem (passed testing)