### PR TITLE
Update skip_before_filter to skip_action_callback

### DIFF
--- a/app/controllers/registrar/sessions_controller.rb
+++ b/app/controllers/registrar/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Registrar::SessionsController < Registrar::ApplicationController
-  skip_before_filter :require_signed_in_user
+  skip_action_callback :require_signed_in_user
 
   def new
   end


### PR DESCRIPTION
In Rails 5.x and greater `skip_before_filter` throws an error with
Registrar (still not quite sure why - will investigate for later PR). In
the mean time, change out the call to skip_before_filter with
skip_action_callback (which gets deprecated in Rails 5.1...).

References:
 * https://github.com/rails/rails/pull/19029
 * http://sssslide.com/speakerdeck.com/claudiob/better-callbacks-in-rails-5