### PR TITLE
Fix the generator for newer rails versions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Registrar::Engine.routes.draw do
 
   get "/auth/google/callback", to: "sessions#create"
 
-  get Registrar.configuration.signin_url, to: "sessions#new", as: "signin"
-  match Registrar.configuration.signout_url, via: [:get, :delete], to: "sessions#destroy", as: "signout"
+  get Registrar.configuration&.signin_url, to: "sessions#new", as: "signin"
+  match Registrar.configuration&.signout_url, via: [:get, :delete], to: "sessions#destroy", as: "signout"
 end

--- a/db/migrate/20150602173954_create_users.rb
+++ b/db/migrate/20150602173954_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration::Current
   def change
     create_table :users do |t|
       t.string :first_name

--- a/lib/generators/registrar/install/install_generator.rb
+++ b/lib/generators/registrar/install/install_generator.rb
@@ -10,8 +10,8 @@ module Registrar
         initializer "registrar.rb" do
           <<-RUBY.strip_heredoc
             Registrar.configure do |config|
-              config.google_client_id = ENV.fetch("GOOGLE_CLIENT_ID")
-              config.google_client_secret = ENV.fetch("GOOGLE_CLIENT_SECRET")
+              config.google_client_id = ENV.fetch("GOOGLE_CLIENT_ID", nil)
+              config.google_client_secret = ENV.fetch("GOOGLE_CLIENT_SECRET", nil)
               config.domain = "your_gmail_domain"
               config.whitelist += %W()
             end


### PR DESCRIPTION
There were a couple of issues with our generators:

* Rails now evaluates the entire project during generation, meaning that
the nil configuration throws an error in our routes.
* ActiveRecord::Migration is deprecated
* The initializer we generate also gets evaluated when we run
migrations, and causes a failure.

Resolves #31 