### PR TITLE
Add `with_user_cookie` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Registrar.configure do |config|
   config.signout_url = "/signout"
   config.after_signin_url = "/"
   config.after_signout_url = "/signout"
+  config.with_user_cookie = true
 end
 ```
 
@@ -61,6 +62,8 @@ end
   through.
 * The `whitelist` option is intended allow specific users from other domains
   access to this application.
+* The `with_user_cookie` option should be used when you need `cookies[:user_id]`
+  to be set during your normal sessions flow.
 
 ## Usage
 For authorization you will have an `require_signed_in_user` method available to you in your

--- a/app/helpers/registrar/sessions_helper.rb
+++ b/app/helpers/registrar/sessions_helper.rb
@@ -1,7 +1,7 @@
 module Registrar::SessionsHelper
   def sign_in(user)
     session[:user_id] = user.id
-    cookies.signed[:user_id] = user.id if with_user_cookie?
+    cookies.encrypted[:user_id] = user.id if with_user_cookie?
 
     current_user = user
   end
@@ -13,7 +13,7 @@ module Registrar::SessionsHelper
   def sign_out
     session[:user_id] = nil
     session[:target] = nil
-    cookies.signed[:user_id] = nil if with_user_cookie?
+    cookies.encrypted[:user_id] = nil if with_user_cookie?
     current_user = nil
   end
 

--- a/app/helpers/registrar/sessions_helper.rb
+++ b/app/helpers/registrar/sessions_helper.rb
@@ -1,6 +1,7 @@
 module Registrar::SessionsHelper
   def sign_in(user)
     session[:user_id] = user.id
+    cookies.signed[:user_id] = user.id if with_user_cookie?
 
     current_user = user
   end
@@ -12,6 +13,7 @@ module Registrar::SessionsHelper
   def sign_out
     session[:user_id] = nil
     session[:target] = nil
+    cookies.signed[:user_id] = nil if with_user_cookie?
     current_user = nil
   end
 
@@ -30,5 +32,9 @@ module Registrar::SessionsHelper
       session[:target] = request.fullpath
       redirect_to registrar.signin_path
     end
+  end
+
+  def with_user_cookie?
+    @_with_user_cookie ||= Registrar.configuration.with_user_cookie
   end
 end

--- a/lib/registrar.rb
+++ b/lib/registrar.rb
@@ -35,11 +35,15 @@ module Registrar
     # Set a url to redirect to after signing out. Defaults to the signin path.
     attr_accessor :after_signout_url
 
+    # Set a user_id cookie on /signin and clear it on /signout. Defaults to false.
+    attr_accessor :with_user_cookie
+
     def initialize
       @whitelist = []
       @after_signin_url = "/"
       @signin_url = "/signin"
       @signout_url = "/signout"
+      @with_user_cookie = false
     end
   end
 end


### PR DESCRIPTION
Add an optional `with_user_cookie` config to set a `user_id` cookie on `/signin` and clear it on `/signout` within the `sign_in` and `sign_out` helper methods. It defaults to `false`.

This could be specifically helpful when [authenticating `ApplicationCable::Connection` with `current_user` using a cookie](http://edgeguides.rubyonrails.org/action_cable_overview.html#connection-setup). Currently the work around I can think of is having a `before_action` that sets the cookie in `ApplicationController` and then skipping it for actions that don't require a user.