### PR TITLE
Support the redirect_uri option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Registrar.configure do |config|
   config.after_signin_url = "/"
   config.after_signout_url = "/signout"
   config.with_user_cookie = true
+  config.redirect_uri = "https://mydomain.com/oauth/consume"
 end
 ```
 
@@ -65,6 +66,8 @@ end
   access to this application.
 * The `with_user_cookie` option should be used when you need `cookies[:user_id]`
   to be set during your normal sessions flow.
+* The `redirect_uri` option should only be used if you don't want to use the
+  default of `<domain initiated from>/auth/google/callback`
 
 ## Usage
 For authorization you will have an `require_signed_in_user` method available to you in your

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,12 +3,11 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     :google_oauth2,
     Registrar.configuration.try(:google_client_id),
     Registrar.configuration.try(:google_client_secret),
-    {
-      scope: "userinfo.email, userinfo.profile",
-      prompt: "select_account",
-      name: "google",
-      image_aspect_ratio: "square",
-      image_size: 50
-    }
+    scope: "userinfo.email, userinfo.profile",
+    prompt: "select_account",
+    name: "google",
+    image_aspect_ratio: "square",
+    image_size: 50,
+    redirect_uri: Registrar.configuration.try(:redirect_uri),
   )
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,13 +1,15 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider(
     :google_oauth2,
-    Registrar.configuration.try(:google_client_id),
-    Registrar.configuration.try(:google_client_secret),
-    scope: "userinfo.email, userinfo.profile",
-    prompt: "select_account",
-    name: "google",
-    image_aspect_ratio: "square",
-    image_size: 50,
-    redirect_uri: Registrar.configuration.try(:redirect_uri),
+    Registrar.configuration&.google_client_id,
+    Registrar.configuration&.google_client_secret,
+    {
+      scope: "userinfo.email, userinfo.profile",
+      prompt: "select_account",
+      name: "google",
+      image_aspect_ratio: "square",
+      image_size: 50,
+      redirect_uri: Registrar.configuration&.redirect_uri,
+    },
   )
 end

--- a/lib/registrar.rb
+++ b/lib/registrar.rb
@@ -13,7 +13,6 @@ module Registrar
   class Configuration
     attr_accessor :google_client_id
     attr_accessor :google_client_secret
-    attr_accessor :redirect_uri
 
     # Domain to validate users against. Anyone who authenticates with an email
     # in this domain will be granted access.
@@ -38,6 +37,9 @@ module Registrar
 
     # Set a user_id cookie on /signin and clear it on /signout. Defaults to false.
     attr_accessor :with_user_cookie
+
+    # Sets your oauth redirect uri
+    attr_accessor :redirect_uri
 
     def initialize
       @whitelist = []

--- a/lib/registrar.rb
+++ b/lib/registrar.rb
@@ -13,6 +13,7 @@ module Registrar
   class Configuration
     attr_accessor :google_client_id
     attr_accessor :google_client_secret
+    attr_accessor :redirect_uri
 
     # Domain to validate users against. Anyone who authenticates with an email
     # in this domain will be granted access.
@@ -44,6 +45,7 @@ module Registrar
       @signin_url = "/signin"
       @signout_url = "/signout"
       @with_user_cookie = false
+      @redirect_uri = nil
     end
   end
 end


### PR DESCRIPTION
Adds the `redirect_uri` configuration option to registrar that just gets passed on to Omniauth.