### PR TITLE
Allow for customizing session identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Registrar
 =========
 
@@ -54,6 +53,8 @@ Registrar.configure do |config|
   config.after_signout_url = "/signout"
   config.with_user_cookie = true
   config.redirect_uri = "https://mydomain.com/oauth/consume"
+  config.session_key = :user_email
+  config.session_manager_class = MySessionManager
 end
 ```
 
@@ -103,8 +104,43 @@ Somewhere on the page you will need the link to authenticate:
 <%= link_to "/auth/google", "/auth/google" %>
 ```
 
+## Custom Session Identifiers
+
+If you don't want the default of `user.id` to be used as your session
+identifier, then you can use the `session_manager_class` setting to provide
+your own class for session management.
+
+```ruby
+# config/initializers/registrar.rb
+
+Registrar.configure do |config|
+  config.session_manager_class = MySessionManager
+end
+```
+
+Your session manager class has to define two methods, `self.session_id` and
+`self.find_by_session_id`. The former is used to determine what to set in
+the session upon successful login, and the latter determines how you look up
+a user with that identifier.
+
+```ruby
+# app/services/my_session_manager.rb
+
+class MySessionManager
+  class << self
+    def session_id(user)
+      user.email
+    end
+
+    def find_by_session_id(session_id)
+      ::User.find_by(email: session_id)
+    end
+  end
+end
+```
+
 ## Licence
-Registrar is copyright © 2016 Procore. It is free software, and may be redistributed under the terms specified in the LICENSE file.
+Registrar is copyright © 2018 Procore. It is free software, and may be redistributed under the terms specified in the LICENSE file.
 
 ## About Procore
 

--- a/app/controllers/registrar/sessions_controller.rb
+++ b/app/controllers/registrar/sessions_controller.rb
@@ -36,6 +36,6 @@ class Registrar::SessionsController < Registrar::ApplicationController
   end
 
   def authorized_email?
-    EmailChecker.new(email).authorized?
+    Registrar::EmailChecker.new(email).authorized?
   end
 end

--- a/app/helpers/registrar/sessions_helper.rb
+++ b/app/helpers/registrar/sessions_helper.rb
@@ -1,7 +1,7 @@
 module Registrar::SessionsHelper
   def sign_in(user)
-    session[:user_id] = user.id
-    cookies.encrypted[:user_id] = user.id if with_user_cookie?
+    session[session_key] = session_manager_class.session_id(user)
+    cookies.encrypted[session_key] = session_manager_class.session_id(user) if with_user_cookie?
 
     current_user = user
   end
@@ -11,9 +11,9 @@ module Registrar::SessionsHelper
   end
 
   def sign_out
-    session[:user_id] = nil
+    session[session_key] = nil
     session[:target] = nil
-    cookies.encrypted[:user_id] = nil if with_user_cookie?
+    cookies.encrypted[session_key] = nil if with_user_cookie?
     current_user = nil
   end
 
@@ -22,7 +22,7 @@ module Registrar::SessionsHelper
   end
 
   def current_user
-    @current_user ||= ::User.find_by(id: session[:user_id])
+    @current_user ||= session_manager_class.find_by_session_id(session[session_key])
   end
 
   private
@@ -36,5 +36,13 @@ module Registrar::SessionsHelper
 
   def with_user_cookie?
     @_with_user_cookie ||= Registrar.configuration.with_user_cookie
+  end
+
+  def session_manager_class
+    Registrar.configuration.session_manager_class
+  end
+
+  def session_key
+    Registrar.configuration.session_key
   end
 end

--- a/app/services/registrar/email_checker.rb
+++ b/app/services/registrar/email_checker.rb
@@ -1,0 +1,25 @@
+class Registrar::EmailChecker
+  attr_reader :email
+
+  def initialize(email)
+    @email = email
+  end
+
+  def authorized?
+    email_in_domain? || whitelisted_email?
+  end
+
+  private
+
+  def email_in_domain?
+    !!domain.match(/^#{Registrar.configuration.domain}$/)
+  end
+
+  def whitelisted_email?
+    Registrar.configuration.whitelist.include?(email)
+  end
+
+  def domain
+    email.split('@').last
+  end
+end

--- a/app/services/registrar/session_manager.rb
+++ b/app/services/registrar/session_manager.rb
@@ -1,0 +1,11 @@
+class Registrar::SessionManager
+  class << self
+    def session_id(user)
+      user.id
+    end
+
+    def find_by_session_id(session_id)
+      ::User.find_by(id: session_id)
+    end
+  end
+end

--- a/lib/registrar.rb
+++ b/lib/registrar.rb
@@ -41,6 +41,12 @@ module Registrar
     # Sets your oauth redirect uri
     attr_accessor :redirect_uri
 
+    # Sets the key to use in the session for identifying the user
+    attr_accessor :session_key
+
+    # Sets the class to use for session management
+    attr_accessor :session_manager_class
+
     def initialize
       @whitelist = []
       @after_signin_url = "/"
@@ -48,6 +54,8 @@ module Registrar
       @signout_url = "/signout"
       @with_user_cookie = false
       @redirect_uri = nil
+      @session_key = :user_id
+      @session_manager_class = Registrar::SessionManager
     end
   end
 end

--- a/spec/controllers/registrar/sessions_controller_spec.rb
+++ b/spec/controllers/registrar/sessions_controller_spec.rb
@@ -7,11 +7,15 @@ RSpec.describe Registrar::SessionsController, type: :controller do
     Registrar.configuration.domain = "example.com"
   end
 
+  after do
+    Registrar.configuration = Registrar::Configuration.new
+  end
+
   describe "GET #new" do
     it "renders the 'new' template" do
       get :new
 
-      expect(response).to  have_http_status(200)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -25,7 +29,7 @@ RSpec.describe Registrar::SessionsController, type: :controller do
 
       post :create
 
-      expect(response).to  have_http_status(200)
+      expect(response).to have_http_status(200)
     end
 
     context "when it is a valid email" do

--- a/spec/helpers/registrar/sessions_helper_spec.rb
+++ b/spec/helpers/registrar/sessions_helper_spec.rb
@@ -1,5 +1,22 @@
 require "rails_helper"
 
+class SpecialSessionsManager
+  class << self
+    def session_id(user)
+      [user.first_name, user.last_name, user.email].join(",")
+    end
+
+    def find_by_session_id(session_id)
+      first_name, last_name, email = session_id.split(",")
+      User.find_by(
+        first_name: first_name,
+        last_name: last_name,
+        email: email,
+      )
+    end
+  end
+end
+
 RSpec.describe Registrar::SessionsHelper, type: :helper do
   let(:user) do
     User.create!(
@@ -9,11 +26,30 @@ RSpec.describe Registrar::SessionsHelper, type: :helper do
     )
   end
 
+  after do
+    Registrar.configuration = Registrar::Configuration.new
+  end
+
   describe "sign_in" do
     it "sets the passed in user's id to session[:user_id]" do
       helper.send(:sign_in, user)
 
       expect(session[:user_id]).to eq(user.id)
+    end
+
+    it "respects custom session keys" do
+      Registrar.configure { |config| config.session_key = :special }
+      helper.send(:sign_in, user)
+
+      expect(session[:special]).to eq(user.id)
+      expect(helper.send(:current_user)).to eq(user)
+    end
+
+    it "respects custom session managers" do
+      Registrar.configure { |config| config.session_manager_class = SpecialSessionsManager }
+      helper.send(:sign_in, user)
+
+      expect(helper.send(:current_user)).to eq(user)
     end
 
     it "sets current_user = user" do


### PR DESCRIPTION
Some applications may want to identify their users by something other than their ID, this should allow them to fully customize how they identify and fetch their users from the session.

Looking for better names for `SessionManager`, as it doesn't really manage anything or give any insight at all into what the class does.