### PR TITLE
Update sign_in link so it hits the correct path

### DIFF
--- a/app/views/registrar/sessions/new.html.erb
+++ b/app/views/registrar/sessions/new.html.erb
@@ -1,1 +1,1 @@
-<%= link_to sign_in_path, "Sign In" %>
+<%= link_to "Sign In", sign_in_path %>


### PR DESCRIPTION
Currently the sign in text is being used as the path.  This PR switches the path and text to where they should be.